### PR TITLE
fix: some test code cause 200 response to be unsuccessful

### DIFF
--- a/Lesson_3/04_Responding to Different Types of Requests/Starter Code/endpoints_tester2.py
+++ b/Lesson_3/04_Responding to Different Types of Requests/Starter Code/endpoints_tester2.py
@@ -28,7 +28,7 @@ try:
 	url = address + "/puppies"
 	h = httplib2.Http()
 	resp, result = h.request(url, 'POST')
-	if resp['status'] != '301':
+	if resp['status'] != '200':
 		raise Exception('Received an unsuccessful status code of %s' % resp['status'])
 
 except Exception as err:
@@ -70,7 +70,7 @@ try:
 		url = address + "/puppies/%s" % id 
 		h = httplib2.Http()
 		resp, result = h.request(url, 'PUT')
-		if resp['status'] != '301':
+		if resp['status'] != '200':
 			raise Exception('Received an unsuccessful status code of %s' % resp['status'])
 		id = id + 1
 
@@ -92,7 +92,7 @@ try:
 		url = address + "/puppies/%s" % id 
 		h = httplib2.Http()
 		resp, result = h.request(url, 'DELETE')
-		if resp['status'] != '301':
+		if resp['status'] != '200':
 			raise Exception('Received an unsuccessful status code of %s' % resp['status'])
 		id = id + 1
 


### PR DESCRIPTION
Originally, some request test has code like this:
resp['status'] != '301': 
    raise Exception('Received an unsuccessful status code of %s' % resp['status']).
This will cause successful response falls into the exception because resp['status']='200'
