### PR TITLE
fix: Deprecated importing of httpauth

### DIFF
--- a/Lesson_4/05_Mom & Pop’s Bagel Shop/Solution Code/views.py
+++ b/Lesson_4/05_Mom & Pop’s Bagel Shop/Solution Code/views.py
@@ -3,7 +3,7 @@ from flask import Flask, jsonify, request, url_for, abort, g
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship, sessionmaker
 from sqlalchemy import create_engine
-from flask.ext.httpauth import HTTPBasicAuth
+from flask_httpauth import HTTPBasicAuth
 
 auth = HTTPBasicAuth() 
 


### PR DESCRIPTION
Importing flask.ext.httpauth is deprecated, use flask_httpauth instead.